### PR TITLE
Fix interpolator range

### DIFF
--- a/src/grids.jl
+++ b/src/grids.jl
@@ -38,8 +38,9 @@ function interpolator(Datumₛ, Datumₜ)
   # lon lat range
   m, n = size(grid)
   A, b = GeoTIFF.affineparams2D(GeoTIFF.metadata(geotiff))
+  # PixelIsPoint convention
   lon₀, lat₀ = muladd(A, SA[0, 0], b)
-  lonₘ, latₙ = muladd(A, SA[m, n], b)
+  lonₘ, latₙ = muladd(A, SA[m - 1, n - 1], b)
 
   # Interpolations.jl requires ordered ranges
   reverselon = lon₀ > lonₘ

--- a/test/converions.jl
+++ b/test/converions.jl
@@ -6,97 +6,101 @@
   # Datum73 to ETRF (ETRS89)
   c1 = LatLon{Datum73}(T(40), T(-8))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(40.00081378249228), T(-7.999087263109144)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(40.00081355417707), T(-7.999086890966467)))
 
   c1 = LatLon{Datum73}(T(40.5), T(-7.5))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(40.50082239831703), T(-7.499060090224424)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(40.500822285541446), T(-7.499059498822431)))
 
   # DHDN to ETRF (ETRS89)
   c1 = LatLon{DHDN}(T(50), T(10))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(49.99884933991171), T(9.99882005851977)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(49.998857302798164), T(9.998811455567678)))
 
   c1 = LatLon{DHDN}(T(50.5), T(10.5))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(50.49879891349057), T(10.498740129905423)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(50.4988057911396), T(10.498728909227584)))
 
   # ED50 to ETRF (ETRS89)
   c1 = LatLon{ED50}(T(42), T(2))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(41.9988941048536), T(1.9988396626107727)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(41.99889344996876), T(1.9988412527243296)))
 
   c1 = LatLon{ED50}(T(42.5), T(2.5))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(42.498911627264604), T(2.498850447396358)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(42.49891144719389), T(2.4988522944185467)))
 
   # ISN93 to ISN2016
   c1 = LatLon{ISN93}(T(65), T(-19))
   c2 = convert(LatLon{ISN2016}, c1)
-  @test allapprox(c2, LatLon{ISN2016}(T(65.00000469860723), T(-19.000005523900196)))
+  @test allapprox(c2, LatLon{ISN2016}(T(65.00000470293945), T(-19.000005506975576)))
 
   c1 = LatLon{ISN93}(T(65.5), T(-18.5))
   c2 = convert(LatLon{ISN2016}, c1)
-  @test allapprox(c2, LatLon{ISN2016}(T(65.50000484426457), T(-18.500005780253733)))
+  @test allapprox(c2, LatLon{ISN2016}(T(65.50000484971433), T(-18.50000577601501)))
 
   # ISN2004 to ISN2016
   c1 = LatLon{ISN2004}(T(65), T(-19))
   c2 = convert(LatLon{ISN2016}, c1)
-  @test allapprox(c2, LatLon{ISN2016}(T(65.0000026741597), T(-19.000002750801873)))
+  @test allapprox(c2, LatLon{ISN2016}(T(65.00000267790941), T(-19.000002746851855)))
 
   c1 = LatLon{ISN2004}(T(65.5), T(-18.5))
   c2 = convert(LatLon{ISN2016}, c1)
-  @test allapprox(c2, LatLon{ISN2016}(T(65.50000273493572), T(-18.500002761930126)))
+  @test allapprox(c2, LatLon{ISN2016}(T(65.5000027383388), T(-18.50000276240546)))
 
   # Lisbon1937 to ETRF (ETRS89)
   c1 = LatLon{Lisbon1937}(T(40), T(-8))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(40.00160827147574), T(-8.001184937478962)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(40.00160819249736), T(-8.001184268660833)))
 
   c1 = LatLon{Lisbon1937}(T(40.5), T(-7.5))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(40.501616799408936), T(-7.501167767618365)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(40.50161713828449), T(-7.501167243650318)))
 
   # NAD27 to NAD83
-  c1 = LatLon{NAD27}(T(30), -T(90))
+  c1 = LatLon{NAD27}(T(30), T(-90))
   c2 = convert(LatLon{NAD83}, c1)
-  @test allapprox(c2, LatLon{NAD83}(T(30.000199294716566), T(-90.00007619090893)))
+  @test allapprox(c2, LatLon{NAD83}(T(30.0002021077772), T(-90.00006962360607)))
+
+  c1 = LatLon{NAD27}(T(35), T(-85))
+  c2 = convert(LatLon{NAD83}, c1)
+  @test allapprox(c2, LatLon{NAD83}(T(35.000075590552555), T(-84.99994750027855)))
 
   # NAD27 to NAD83(CSRS)v2
-  c1 = LatLon{NAD27}(T(50), -T(70))
+  c1 = LatLon{NAD27}(T(50), T(-70))
   c2 = convert(LatLon{NAD83CSRS{2}}, c1)
-  @test allapprox(c2, LatLon{NAD83CSRS{2}}(T(50.0000398581475), T(-69.999506322228)))
+  @test allapprox(c2, LatLon{NAD83CSRS{2}}(T(50.0000388027769), T(-69.99950693332487)))
 
-  c1 = LatLon{NAD27}(T(55), -T(65))
+  c1 = LatLon{NAD27}(T(55), T(-65))
   c2 = convert(LatLon{NAD83CSRS{2}}, c1)
-  @test allapprox(c2, LatLon{NAD83CSRS{2}}(T(55.00009359355559), T(-64.99919973281575)))
+  @test allapprox(c2, LatLon{NAD83CSRS{2}}(T(55.00009247500036), T(-64.99919871389866)))
 
   # NAD27 to NAD83(CSRS)v3
-  c1 = LatLon{NAD27}(T(43.6), -T(79.5))
+  c1 = LatLon{NAD27}(T(43.6), T(-79.5))
   c2 = convert(LatLon{NAD83CSRS{3}}, c1)
-  @test allapprox(c2, LatLon{NAD83CSRS{3}}(T(43.600055439398375), T(-79.49980272005197)))
+  @test allapprox(c2, LatLon{NAD83CSRS{3}}(T(43.600055438888575), T(-79.4998027083277)))
 
-  c1 = LatLon{NAD27}(T(43.8), -T(79.3))
+  c1 = LatLon{NAD27}(T(43.8), T(-79.3))
   c2 = convert(LatLon{NAD83CSRS{3}}, c1)
-  @test allapprox(c2, LatLon{NAD83CSRS{3}}(T(43.800054768403086), T(-79.29980046013165)))
+  @test allapprox(c2, LatLon{NAD83CSRS{3}}(T(43.80005476944562), T(-79.2998004666633)))
 
   # OSGB36 to ETRF (ETRS89)
   c1 = LatLon{OSGB36}(T(55), T(-3.5))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(55.00005596760369), T(-3.5013430674408594)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(55.00005659972214), T(-3.501344154410892)))
 
   c1 = LatLon{OSGB36}(T(55.5), T(-2))
   c2 = convert(LatLon{ETRFLatest}, c1)
-  @test allapprox(c2, LatLon{ETRFLatest}(T(55.500012794470535), T(-2.001564313021665)))
+  @test allapprox(c2, LatLon{ETRFLatest}(T(55.50001349305527), T(-2.0015656316280364)))
 
   # SAD96 to SIRGAS2000
   c1 = LatLon{SAD96}(T(-15), T(-45))
   c2 = convert(LatLon{SIRGAS2000}, c1)
-  @test allapprox(c2, LatLon{SIRGAS2000}(T(-15.000451566492272), T(-45.00042666174454)))
+  @test allapprox(c2, LatLon{SIRGAS2000}(T(-15.000452247228887), T(-45.00042616943518)))
 
   c1 = LatLon{SAD96}(T(-10), T(-40))
   c2 = convert(LatLon{SIRGAS2000}, c1)
-  @test allapprox(c2, LatLon{SIRGAS2000}(T(-10.000428915126209), T(-40.00037063898611)))
+  @test allapprox(c2, LatLon{SIRGAS2000}(T(-10.000429661108388), T(-40.000369772215684)))
 
   # Point Motion with Velocity Grids
   # note: the results differ from PROJ because we use the standard implementation described
@@ -105,63 +109,63 @@
   # NAD83(CSRS)v3 to NAD83(CSRS)v4
   c1 = LatLonAlt{NAD83CSRS{3}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{4}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{4}}(T(59.999999938434975), T(-89.99999975034973), T(1.037781248477583)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{4}}(T(59.999999938645644), T(-89.99999975269422), T(1.0371961307525634)))
 
   c1 = LatLonAlt{NAD83CSRS{3}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{4}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{4}}(T(64.99999994796659), T(-84.99999974705766), T(1.0365328033839258)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{4}}(T(64.99999994769557), T(-84.99999974497726), T(1.0369444847106934)))
 
   # NAD83(CSRS)v3 to NAD83(CSRS)v6
   c1 = LatLonAlt{NAD83CSRS{3}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{6}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(59.999999839930936), T(-89.99999935090928), T(1.098231246041716)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(59.99999984047868), T(-89.99999935700498), T(1.096709939956665)))
 
   c1 = LatLonAlt{NAD83CSRS{3}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{6}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(64.99999986471312), T(-84.99999934234988), T(1.0949852887982072)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(64.99999986400846), T(-84.99999933694087), T(1.0960556602478027)))
 
   # NAD83(CSRS)v3 to NAD83(CSRS)v7
   c1 = LatLonAlt{NAD83CSRS{3}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{7}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(59.999999839930936), T(-89.99999935090928), T(1.098231246041716)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(59.99999984047868), T(-89.99999935700498), T(1.096709939956665)))
 
   c1 = LatLonAlt{NAD83CSRS{3}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{7}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(64.99999986471312), T(-84.99999934234988), T(1.0949852887982072)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(64.99999986400846), T(-84.99999933694087), T(1.0960556602478027)))
 
   # NAD83(CSRS)v3 to NAD83(CSRS)v8
   c1 = LatLonAlt{NAD83CSRS{3}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{8}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(59.999999839930936), T(-89.99999935090928), T(1.098231246041716)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(59.99999984047868), T(-89.99999935700498), T(1.096709939956665)))
 
   c1 = LatLonAlt{NAD83CSRS{3}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{8}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(64.99999986471312), T(-84.99999934234988), T(1.0949852887982072)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(64.99999986400846), T(-84.99999933694087), T(1.0960556602478027)))
 
   # NAD83(CSRS)v4 to NAD83(CSRS)v6
   c1 = LatLonAlt{NAD83CSRS{4}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{6}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(59.99999990149597), T(-89.99999960055956), T(1.060449997564133)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(59.99999990183303), T(-89.99999960431076), T(1.0595138092041017)))
 
   c1 = LatLonAlt{NAD83CSRS{4}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{6}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(64.99999991674655), T(-84.99999959529225), T(1.0584524854142814)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{6}}(T(64.99999991631289), T(-84.99999959196361), T(1.0591111755371094)))
 
   # NAD83(CSRS)v4 to NAD83(CSRS)v7
   c1 = LatLonAlt{NAD83CSRS{4}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{7}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(59.99999990149597), T(-89.99999960055956), T(1.060449997564133)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(59.99999990183303), T(-89.99999960431076), T(1.0595138092041017)))
 
   c1 = LatLonAlt{NAD83CSRS{4}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{7}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(64.99999991674655), T(-84.99999959529225), T(1.0584524854142814)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{7}}(T(64.99999991631289), T(-84.99999959196361), T(1.0591111755371094)))
 
   # NAD83(CSRS)v4 to NAD83(CSRS)v8
   c1 = LatLonAlt{NAD83CSRS{4}}(T(60), T(-90), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{8}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(59.99999990149597), T(-89.99999960055956), T(1.060449997564133)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(59.99999990183303), T(-89.99999960431076), T(1.0595138092041017)))
 
   c1 = LatLonAlt{NAD83CSRS{4}}(T(65), T(-85), T(1))
   c2 = convert(LatLonAlt{NAD83CSRS{8}}, c1)
-  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(64.99999991674655), T(-84.99999959529225), T(1.0584524854142814)))
+  @test allapprox(c2, LatLonAlt{NAD83CSRS{8}}(T(64.99999991631289), T(-84.99999959196361), T(1.0591111755371094)))
 end


### PR DESCRIPTION
All grids hosted on the PROJ CDN use `PixelIsPoint` by default:

![image](https://github.com/user-attachments/assets/a6091d0b-d2e2-4b21-b13c-3dcd196770a2)

link: https://proj.org/en/stable/specifications/geodetictiffgrids.html
